### PR TITLE
Fix script header (encoding + /usr/bin/env)

### DIFF
--- a/csub
+++ b/csub
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+# -*- coding: utf8 -*-it
 # pylint: disable=no-member
 """
 csub is a python script to improve user experience with HTCondor batch scheduler


### PR DESCRIPTION
Fix script header
# !/usr/bin/env python instead of #!/usr/bin/python

and add utf-8 encoding
