### PR TITLE
osx-issue

### DIFF
--- a/csub
+++ b/csub
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf8 -*-fr
 # pylint: disable=no-member
 """
@@ -14,7 +14,7 @@ import classad
 
 
 __author__ = 'Guillaume Philippon <guillaume.philippon@lal.in2p3.fr>'
-__version__ = 1.0
+__version__ = '1.0'
 
 
 class UserNotInGroup(Exception):


### PR DESCRIPTION
Condor libraries are .so file dynamicaly linked to OS-X embeded python.
If you upgrade python version from python.org, importing htcondor or classad
failed
